### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -9,6 +9,8 @@ from django.views.decorators.csrf import csrf_exempt
 import json
 from datetime import datetime, timedelta
 from django.conf import settings
+import logging
+logging.basicConfig(level=logging.ERROR)
 
 def get_secret_key():
     """Returns a predefined secret key."""
@@ -96,14 +98,16 @@ class DecryptView(View):
                 shift_value = 3
                 decryption_key = caesar_decipher(secret_key, shift_value)
             except Exception as e:
-                return JsonResponse({"status": "error", "message": f"Failed to retrieve decryption key: {str(e)}", "data": None}, status=500)
+                logging.error(f"Failed to retrieve decryption key: {str(e)}")
+                return JsonResponse({"status": "error", "message": "Failed to retrieve decryption key.", "data": None}, status=500)
 
             try:
                 decrypted_text = decrypt_aes_js_style(encrypted_message, decryption_key)
                 if not decrypted_text:
                     raise ValueError("Decryption returned empty result.")
             except Exception as e:
-                return JsonResponse({"status": "error", "message": f"Decryption failed: {str(e)}", "data": None}, status=400)
+                logging.error(f"Decryption failed: {str(e)}")
+                return JsonResponse({"status": "error", "message": "Decryption failed.", "data": None}, status=400)
 
             try:
                 course_id, meet_id, date, start, end = decrypted_text.split(',')
@@ -124,7 +128,8 @@ class DecryptView(View):
             }, status=200)
 
         except Exception as e:
-            return JsonResponse({"status": "error", "message": f"Unexpected error: {str(e)}", "data": None}, status=500)
+            logging.error(f"Unexpected error: {str(e)}")
+            return JsonResponse({"status": "error", "message": "An unexpected error has occurred.", "data": None}, status=500)
 
 @method_decorator(csrf_exempt, name='dispatch')
 class EncryptView(View):


### PR DESCRIPTION
Potential fix for [https://github.com/ridwaanhall/Lumina/security/code-scanning/2](https://github.com/ridwaanhall/Lumina/security/code-scanning/2)

To fix the problem, we need to ensure that detailed error messages are not exposed to the user. Instead, we should log the detailed error messages on the server side and return a generic error message to the user. This can be achieved by modifying the exception handling blocks to log the exceptions and return a generic error message.

1. Import the `logging` module to enable logging of exceptions.
2. Replace the detailed error messages returned to the user with generic messages.
3. Log the detailed error messages on the server side.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
