### PR TITLE
Potential fix for code scanning alert no. 9: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -33,16 +33,9 @@ def caesar_decipher(text, shift):
     """Decrypts text using a simple Caesar cipher."""
     return caesar_cipher(text, 26 - shift)
 
-def derive_key_and_iv(password, salt, key_length=32, iv_length=16):
-    """Derives a key and IV from the password and salt, replicating CryptoJS behavior."""
-    password_bytes = password.encode('utf-8')
-    key_iv = b""
-    digest = b""
-    
-    while len(key_iv) < key_length + iv_length:
-        digest = hashlib.md5(digest + password_bytes + salt).digest()
-        key_iv += digest
-    
+def derive_key_and_iv(password, salt, key_length=32, iv_length=16, iterations=100000):
+    """Derives a key and IV from the password and salt using PBKDF2."""
+    key_iv = hashlib.pbkdf2_hmac('sha256', password.encode('utf-8'), salt, iterations, dklen=key_length + iv_length)
     return key_iv[:key_length], key_iv[key_length:key_length + iv_length]
 
 def decrypt_aes_js_style(encrypted_text_b64, key):


### PR DESCRIPTION
Potential fix for [https://github.com/ridwaanhall/Lumina/security/code-scanning/9](https://github.com/ridwaanhall/Lumina/security/code-scanning/9)

To fix the problem, we need to replace the use of the MD5 hashing algorithm with a stronger, more secure hashing algorithm. In this case, we can use PBKDF2 (Password-Based Key Derivation Function 2) from the `hashlib` library, which is designed to be computationally expensive and includes a salt by default. This will ensure that the derived key and IV are generated securely.

We will modify the `derive_key_and_iv` function to use `hashlib.pbkdf2_hmac` instead of `hashlib.md5`. This change will involve updating the function to use PBKDF2 with a suitable number of iterations and the SHA-256 hash function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
